### PR TITLE
Fix exception if no backend user is logged in

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,6 +7,6 @@ return [
      * by default use Backend user timezone : \Backend\Models\Preference::get('timezone')
      * but you can override it to a regional timezone e.g.: 'Europe/Zurich'
      */
-    'timezone' => BackendAuth::getUser() ? \Backend\Models\Preference::get('timezone') : 'UTC',
+    'timezone' => BackendAuth::getUser() ? \Backend\Models\Preference::get('timezone') : null,
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -7,6 +7,6 @@ return [
      * by default use Backend user timezone : \Backend\Models\Preference::get('timezone')
      * but you can override it to a regional timezone e.g.: 'Europe/Zurich'
      */
-    'timezone' => \Backend\Models\Preference::get('timezone'),
+    'timezone' => BackendAuth::getUser() ? \Backend\Models\Preference::get('timezone') : 'UTC',
 
 ];


### PR DESCRIPTION
@ChVuagniaux unless you have a cleaner way to do this.

Before this fix:
Trying to access a controller implementing `RevisionableController` without being logged in would display an Exception and write an entry in the error log.

With this fix:
Like without `RevisionableController`: the user is redirected to the login page and intended url is saved for post-login.